### PR TITLE
feat(texts): add line break for text

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -122,7 +122,17 @@ local things = function(link)
   return function() os.execute(string.format("open %s", link)) end
 end
 local text = function(s)
-  return function() hs.eventtap.keyStrokes(s) end
+  return function() 
+		local is_first_line = true
+		for _, line in ipairs(split(s, "\n")) do
+			if is_first_line then
+				is_first_line = false
+			else
+				hs.eventtap.keyStroke({}, "return")
+			end
+			hs.eventtap.keyStrokes(line)
+		end
+  end
 end
 local keystroke = function(keystroke)
   local mods, key = parseKeystroke(keystroke)

--- a/init.lua
+++ b/init.lua
@@ -128,7 +128,7 @@ local text = function(s)
 			if is_first_line then
 				is_first_line = false
 			else
-				hs.eventtap.keyStroke({}, "return")
+				hs.eventtap.keyStroke({"shift"}, "return")
 			end
 			hs.eventtap.keyStrokes(line)
 		end


### PR DESCRIPTION
Thank you so much for Hammerflow. It is an amazing daily helper. 

This PR adds the feature to use texts including new lines "\n". It allows the text action to insert a broader range of different snippets.

e.g. ```l = ["text:Thank you,\nFranz", "TY"]``` produces:

```
Thank you,
Franz
```

Thanks for considering the update!